### PR TITLE
refactor: Round Z-score calculations, add docs, and adjust tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ default-members = [
 ]
 
 [workspace.dependencies]
-polars = {version = "0.46.0", features = ["lazy", "ndarray"]}
+polars = {version = "0.46.0", features = ["lazy", "ndarray", "round_series"]}
 thiserror = "2.0.11"
 rayon = "1.10.0"
 ndarray = {version = "0.16.1", features = ["approx"]}

--- a/crates/clamsform-core/src/scaling/traits.rs
+++ b/crates/clamsform-core/src/scaling/traits.rs
@@ -4,7 +4,7 @@ use super::standardization::errors::ScalingError;
 
 pub trait FeatureScaler {
     /// Computes scaling parameters and returns the transformed dataframe
-    fn standardize(&mut self, df: &DataFrame) -> Result<DataFrame, ScalingError>;
+    fn standardize(&mut self, df: &DataFrame, decimals: u32) -> Result<DataFrame, ScalingError>;
 
     /// Reset internal state
     fn reset(&mut self);


### PR DESCRIPTION
- Added `decimals` parameter to `standardize()` method
- Added and updated documentation around Z-scores
- Adjusted Z-score tests to factor into account rounding parameter 